### PR TITLE
feat: add basic metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b683cbc43010e9a3d72c2f31ca464155ff4f95819e88a32924b0f47a43898978"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tower-http",
+]
+
+[[package]]
 name = "axum-test"
 version = "15.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +457,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -800,6 +831,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1286,6 +1320,48 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64",
+ "hyper 0.14.29",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -2060,6 +2136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +2904,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-jsonschema",
+ "axum-prometheus",
  "axum-test",
  "axum-valid",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,10 @@ axum-valid = { version = "0.18.0", features = [
   "garde",
 ], default-features = false }
 garde = { version = "0.18.0", features = ["derive", "url"] }
+axum-prometheus = "0.6.1"
 
 [dev-dependencies]
+axum-test = "15.3.0"
 chrono = { version = "0.4.38" }
 httpc-test = "0.1.9"
 pretty_assertions = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The response contain a non `200` HTTP status code, such as `400`, with a body li
 }
 ```
 
+## Metrics
+
+Some very basic [Prometheus](https://prometheus.io/) metrics are exported at the `/metrics` endpoint.
+
 ## Thanks
 
 This API was originally inspired by and contains some data gathered from [this dataset on kaggle](https://www.kaggle.com/datasets/karnikakapoor/wonders-of-world).

--- a/tests/routes_docs.rs
+++ b/tests/routes_docs.rs
@@ -1,0 +1,22 @@
+use world_wonders_api::DOCS_ROUTE;
+
+mod common;
+use common::get_server;
+
+#[tokio::test]
+async fn test_routes_docs() {
+    let server = get_server();
+
+    let response = server.get(DOCS_ROUTE).await;
+    response.assert_status_ok();
+    assert_eq!(response.header("content-type"), "text/html; charset=utf-8");
+    assert!(
+        response
+            .header("content-length")
+            .to_str()
+            .unwrap()
+            .parse::<usize>()
+            .unwrap()
+            > 1000000
+    );
+}

--- a/tests/routes_misc.rs
+++ b/tests/routes_misc.rs
@@ -1,25 +1,23 @@
 use pretty_assertions::assert_eq;
 
-use world_wonders_api::DOCS_ROUTE;
+use world_wonders_api::METRICS_ROUTE;
 
 mod common;
 use common::get_server;
 
 #[tokio::test]
-async fn test_404() {
+async fn test_routes_misc() {
     let server = get_server();
 
+    // 404
     let response = server.get("not-a-route").await;
     response.assert_status_not_found();
     response.assert_text_contains("Route not found");
-}
 
-#[tokio::test]
-async fn test_docs() {
-    let server = get_server();
-
-    let response = server.get(DOCS_ROUTE).await;
+    // METRICS
+    let response = server.get(METRICS_ROUTE).await;
     response.assert_status_ok();
+    assert_eq!(response.header("content-type"), "text/plain; charset=utf-8");
     assert!(
         response
             .header("content-length")
@@ -27,7 +25,6 @@ async fn test_docs() {
             .unwrap()
             .parse::<usize>()
             .unwrap()
-            > 1000000
+            > 1000
     );
-    assert_eq!(response.header("content-type"), "text/html; charset=utf-8");
 }

--- a/tests/routes_wonders.rs
+++ b/tests/routes_wonders.rs
@@ -10,7 +10,7 @@ mod common;
 use common::get_server;
 
 #[tokio::test]
-async fn test_wonders() {
+async fn test_routes_wonders() {
     let server = get_server();
 
     // All wonders


### PR DESCRIPTION
Basic metrics exported in the Prometheus format. Also needed to split up integration tests as the global setting of the recorder for the metrics was causing panics.