### PR TITLE
feat: add a simple health check route

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use aide::{
 };
 use axum::{
     extract::{MatchedPath, Request},
-    http::Method,
+    http::{self, Method},
     Extension, Router,
 };
 use axum_prometheus::PrometheusMetricLayer;
@@ -31,6 +31,7 @@ pub mod routes;
 pub const DOCS_ROUTE: &str = "/v0/docs";
 pub const WONDERS_ROUTE: &str = "/v0/wonders";
 pub const METRICS_ROUTE: &str = "/metrics";
+pub const HEALTH_ROUTE: &str = "/health";
 
 pub fn get_app() -> Router {
     // API docs generation
@@ -62,6 +63,10 @@ pub fn get_app() -> Router {
         .nest_api_service(WONDERS_ROUTE, wonders::routes())
         .nest_api_service(DOCS_ROUTE, docs::routes())
         .api_route(METRICS_ROUTE, get(|| async move { metric_handle.render() }))
+        .api_route(
+            HEALTH_ROUTE,
+            get(|| async { (http::StatusCode::OK, "Healthy!") }),
+        )
         .fallback(handler_404)
         .finish_api_with(&mut api, api_docs)
         // Docs generation

--- a/tests/routes_misc.rs
+++ b/tests/routes_misc.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use world_wonders_api::METRICS_ROUTE;
+use world_wonders_api::{HEALTH_ROUTE, METRICS_ROUTE};
 
 mod common;
 use common::get_server;
@@ -7,6 +7,11 @@ use common::get_server;
 #[tokio::test]
 async fn test_routes_misc() {
     let server = get_server();
+
+    // HEALTH
+    let response = server.get(HEALTH_ROUTE).await;
+    response.assert_status_ok();
+    response.assert_text_contains("Healthy!");
 
     // 404
     let response = server.get("not-a-route").await;


### PR DESCRIPTION
Useful for providing a way to check the status of the public instance that is light on resources. The plan is to use something simple and continuous, such as [uptime-kuma](https://github.com/louislam/uptime-kuma).